### PR TITLE
Fix banner css link

### DIFF
--- a/banner.js
+++ b/banner.js
@@ -9,6 +9,6 @@ document.addEventListener('DOMContentLoaded', function () {
 	<a href="https://bots.delta.chat">bots</a>
 	 &middot; 
 	<a href="https://cosmos.delta.chat">cosmos</a>
-</div><link rel="stylesheet" type="text/css" href="./banner.css">`;
+</div><link rel="stylesheet" type="text/css" href="https://cosmos.delta.chat/banner.css">`;
 	document.body.style.paddingBottom = document.querySelector('.deltachat-banner').getBoundingClientRect().height + 'px'
 });


### PR DESCRIPTION
Closes https://github.com/deltachat/cosmos/issues/18 and various other issues. Mistakenly was using a relative path when it should be the full URL. Thanks @r10s for noticing and documenting this.