### PR TITLE
invite-links use i.delta.chat

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,7 +123,7 @@ td:nth-of-type(n+2) {
 </tr>
 <tr>
   <td>invite</td>
-  <td><a href="https://invite.delta.chat">invite.<wbr>delta.chat</a></td>
+  <td><a href="https://i.delta.chat">i.<wbr>delta.chat</a></td>
   <td><a href="https://github.com/deltachat/invite">deltachat/invite</a></td>
 </tr>
 <tr>


### PR DESCRIPTION
invite-links use i.delta.chat; invite.delta.chat is not understood by all layers

cmp.  https://github.com/deltachat/sysadmin/issues/140