### PR TITLE
ci: use environment secrets for production

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -9,6 +9,8 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
+    environment:
+      name: "production"
 
     steps:
     - uses: GuillaumeFalourd/clone-github-repo-action@v2

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,12 +13,12 @@ jobs:
       name: "production"
 
     steps:
-    - uses: GuillaumeFalourd/clone-github-repo-action@v2
+    - uses: GuillaumeFalourd/clone-github-repo-action@19817562c346ff60f9935158dede6c5ece8fd0ac  # v2.3
       with:
         owner: 'deltachat'
         repository: 'cosmos'
     - name: Upload
-      uses: horochx/deploy-via-scp@1.1.0
+      uses: horochx/deploy-via-scp@c82b42f002701aeca107ef7cf6ea4efe6788141e  # 1.1.0
       with:
         user: ${{ secrets.USERNAME }}
         key: ${{ secrets.KEY }}


### PR DESCRIPTION
To deprecate the old key, we need to:

- [x] merge this PR
- [x] deploy https://github.com/deltachat/sysadmin/pull/285
- [x] delete the repository-wide secret