### PR TITLE
ci: use rsync for deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,12 +18,8 @@ jobs:
         owner: 'deltachat'
         repository: 'cosmos'
     - name: Upload
-      uses: horochx/deploy-via-scp@c82b42f002701aeca107ef7cf6ea4efe6788141e  # 1.1.0
-      with:
-        user: ${{ secrets.USERNAME }}
-        key: ${{ secrets.KEY }}
-        host: "delta.chat"
-        port: 22
-        local: "cosmos"
-        remote: "/var/www/html/"
-
+      run: |
+        mkdir -p "$HOME/.ssh"
+        echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
+        chmod 600 "$HOME/.ssh/key"
+        rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/cosmos "${{ secrets.USERNAME }}@delta.chat:/var/www/html/"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,4 +22,4 @@ jobs:
         mkdir -p "$HOME/.ssh"
         echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
         chmod 600 "$HOME/.ssh/key"
-        rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/cosmos/* "${{ secrets.USERNAME }}@cosmos.delta.chat:"
+        rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/cosmos/ "${{ secrets.USERNAME }}@cosmos.delta.chat:"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,4 +22,4 @@ jobs:
         mkdir -p "$HOME/.ssh"
         echo "${{ secrets.KEY }}" > "$HOME/.ssh/key"
         chmod 600 "$HOME/.ssh/key"
-        rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/cosmos "${{ secrets.USERNAME }}@delta.chat:/var/www/html/"
+        rsync -rILvh -e "ssh -i $HOME/.ssh/key -o StrictHostKeyChecking=no" $GITHUB_WORKSPACE/cosmos/* "${{ secrets.USERNAME }}@cosmos.delta.chat:"


### PR DESCRIPTION
This is necessary because https://github.com/deltachat/sysadmin/issues/270 switches our server-side authentication to rrsync and scp won't work anymore.

We need to re-run CI after migrating page to www.